### PR TITLE
Cambios:

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <link rel="stylesheet" href="./src/scss/style.scss" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "project-gamma",
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,6 @@ import { Link, Route, Routes } from "react-router-dom";
 import Home from "./views/Home";
 import Contact from "./views/contact/Contact";
 import Styleguide from "./styleguide/views-sg/Styleguide";
-import "./App.css";
 import "./scss/style.scss";
 
 function App() {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
-import "./index.scss";
 import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.createRoot(document.getElementById("root")).render(

--- a/src/scss/_typography.scss
+++ b/src/scss/_typography.scss
@@ -1,13 +1,5 @@
-@font-face {
-    font-family: 'Roboto';
-    src: url('https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap');
-}
 
-@font-face {
-    font-family: 'Oswald';
-    src: url("https://fonts.googleapis.com/css2?family=Oswald:wght@600&display=swap");
-}
-
+@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@300;600&family=Roboto:wght@300&display=swap');
 
 $font-primary: 'Roboto';
 $font-secondary: 'Oswald';


### PR DESCRIPTION
- Eliminado un import de SCSS en index.html que duplicaba el CSS.
- Eliminado un import al viejo CSS en el archivo app.jsx que trae VITE por defecto para evitar confusiones o conflictos
- Eliminado un import a un archivo index.scss en el archivo main.jsx que no debe estar (Si lo queremos usar, que esté en la carpeta scss e importado en global.scss)
- Por algún motivo, la recomendación que me daba Google Fonts para importar las fuentes, es diferente a la que tú usabas. La he actualizado y parece funcionar.